### PR TITLE
🐛 [WebBrowserExtensionClient] Javascript Async operations are awaitable from Dart.

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.5"
+    version: "1.2.6"
   archive:
     dependency: transitive
     description:

--- a/lib/src/transport/webbrowser_extension/webbrowser_extension.js.dart
+++ b/lib/src/transport/webbrowser_extension/webbrowser_extension.js.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_setters_without_getters
+
 @JS()
 library awc;
 
@@ -19,28 +21,34 @@ class AWCStreamChannelJS {
   @JS('state')
   external AWCStreamChannelState get state;
 
+  /// This returns a promise.
+  /// You must use `promiseTofuture` to call this from Dart code.
   @JS('connect')
-  external Future<void> connect();
+  external Object connect();
 
+  /// This returns a promise.
+  /// You must use `promiseTofuture` to call this from Dart code.
   @JS('close')
-  external Future<void> close();
+  external Object close();
 
+  /// This returns a promise.
+  /// You must use `promiseTofuture` to call this from Dart code.
   @JS('send')
-  external Future<void> send(String data);
+  external Object send(String data);
 
   @JS('onReceive')
-  external set onReceive(Future<void> Function(String data));
+  external set onReceive(Future<void> Function(String data) callback);
 
   @JS('onReady')
-  external set onReady(Future<void> Function());
+  external set onReady(Future<void> Function() callback);
 
   @JS('onClose')
-  external set onClose(Future<void> Function(String reason));
+  external set onClose(Future<void> Function(String reason) callback);
 }
 
 enum AWCStreamChannelState {
-  CONNECTING,
-  OPEN,
-  CLOSING,
-  CLOSED,
+  connecting,
+  open,
+  closing,
+  closed,
 }


### PR DESCRIPTION
Some async operations (connect, disconnect..) were not correctly awaitable from Dart client.

This is now fixed.

This PR pairs with https://github.com/archethic-foundation/archethic-dapp-framework-flutter/pull/9